### PR TITLE
Add filtering

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ This is inteded to help keep people informed about notable changes between
 versions as well as provide a rough history.
 
 #### Next Release
+* Added filtering of current list of pull requests
 
 #### v2.0.0
 * Added ability to refresh pull requests

--- a/lib/pra/curses_window_system.rb
+++ b/lib/pra/curses_window_system.rb
@@ -220,7 +220,8 @@ module Pra
     def filter_current_pull_requests(input_string)
       pull_reqs = @current_pull_requests.keep_if do |pr|
         columns.any? do |col|
-          pr_attr_value = pr.send(col[:name])
+          presenter = Pra::CursesPullRequestPresenter.new(pr)
+          pr_attr_value = presenter.send(col[:name])
           next if pr_attr_value.nil?
           if input_string == input_string.downcase
             pr_attr_value.to_s.downcase.include?(input_string)

--- a/lib/pra/curses_window_system.rb
+++ b/lib/pra/curses_window_system.rb
@@ -8,6 +8,8 @@ require 'thread'
 module Pra
   class CursesWindowSystem < Pra::WindowSystem
     ENTER_KEY = 10
+    ESC_KEY = 27
+    BACKSPACE_KEY = 127
 
     def initialize
       @selected_pull_request_page_index = 0
@@ -19,6 +21,8 @@ module Pra
       @last_updated_access_lock = Mutex.new
       @force_update = true
       @force_update_access_lock = Mutex.new
+      @filter_mode = false
+      @filter_string = ""
     end
 
     def last_updated
@@ -72,27 +76,55 @@ module Pra
     def run_loop
       c = Curses.getch()
       while (c != 'q') do
-        case c
-        when 'j', Curses::Key::DOWN
-          move_selection_down
-          draw_current_pull_requests
-        when 'k', Curses::Key::UP
-          move_selection_up
-          draw_current_pull_requests
-        when 'r'
-          @force_update = true
-        when 'o', ENTER_KEY
-          @state_lock.synchronize {
-            Launchy.open(@current_pull_requests[selected_pull_request_loc].link)
-          }
-        when 'n'
-          load_next_page
-        when 'p'
-          load_prev_page
-        when '/'
-          c_str = Curses.getstr()
-          clear_pull_requests
-          filter_current_pull_requests(c_str)
+        if @filter_mode
+          case c
+          when ESC_KEY
+            @filter_mode = false
+            @filter_string = ""
+            Curses.setpos(5, 0)
+            Curses.clrtoeol
+            @current_pull_requests = @original_pull_requests.dup
+            @original_pull_requests = nil
+            draw_current_pull_requests
+          when ENTER_KEY
+            @filter_mode = false
+            @filter_string = ""
+          when "\b", BACKSPACE_KEY, Curses::KEY_BACKSPACE
+            @filter_string.chop!
+            output_string(5, 0, "Filter: #{@filter_string}")
+            clear_pull_requests
+            filter_current_pull_requests(@filter_string)
+          when String
+            @filter_string += c
+            output_string(5, 0, "Filter: #{@filter_string}")
+            clear_pull_requests
+            filter_current_pull_requests(@filter_string)
+          end
+        else
+          case c
+          when 'j', Curses::Key::DOWN
+            move_selection_down
+            draw_current_pull_requests
+          when 'k', Curses::Key::UP
+            move_selection_up
+            draw_current_pull_requests
+          when 'r'
+            @force_update = true
+            Curses.setpos(5, 0)
+            Curses.clrtoeol
+          when 'o', ENTER_KEY
+            @state_lock.synchronize {
+              Launchy.open(@current_pull_requests[selected_pull_request_loc].link)
+            }
+          when 'n'
+            load_next_page
+          when 'p'
+            load_prev_page
+          when '/'
+            @filter_mode = true
+            @original_pull_requests = @current_pull_requests.dup
+            output_string(5, 0, "Filter: #{@filter_string}")
+          end
         end
         c = Curses.getch()
       end
@@ -217,7 +249,7 @@ module Pra
     end
 
     def filter_current_pull_requests(input_string)
-      pull_reqs = @current_pull_requests.keep_if do |pr|
+      pull_reqs = @original_pull_requests.dup.keep_if do |pr|
         columns.any? do |col|
           presenter = Pra::CursesPullRequestPresenter.new(pr)
           pr_attr_value = presenter.send(col[:name])

--- a/lib/pra/curses_window_system.rb
+++ b/lib/pra/curses_window_system.rb
@@ -91,9 +91,8 @@ module Pra
           load_prev_page
         when '/'
           c_str = Curses.getstr()
-          filter_current_pull_requests(c_str)
           clear_pull_requests
-          draw_current_pull_requests
+          filter_current_pull_requests(c_str)
         end
         c = Curses.getch()
       end
@@ -128,7 +127,7 @@ module Pra
 
     def display_instructions
       output_string(0, 0, "Pra: Helping you own pull requests")
-      output_string(1, 0, "quit: q, up: k|#{"\u25B2".encode("UTF-8")}, down: j|#{"\u25BC".encode("UTF-8")}, open: o|#{"\u21A9".encode("UTF-8")}, refresh: r, next page: n, prev page: p, search: /")
+      output_string(1, 0, "quit: q, up: k|#{"\u25B2".encode("UTF-8")}, down: j|#{"\u25BC".encode("UTF-8")}, open: o|#{"\u21A9".encode("UTF-8")}, refresh: r, next page: n, prev page: p, filter: /")
     end
 
     def move_selection_up
@@ -231,11 +230,7 @@ module Pra
         end
       end
 
-      @previous_number_of_pull_requests = @current_pull_requests.length
-      @state_lock.synchronize {
-        @current_pull_requests = pull_reqs.dup
-        @last_updated = Time.now
-      }
+      refresh_pull_requests(pull_reqs)
     end
 
     def draw_current_pull_requests

--- a/lib/pra/curses_window_system.rb
+++ b/lib/pra/curses_window_system.rb
@@ -221,7 +221,6 @@ module Pra
         columns.any? do |col|
           presenter = Pra::CursesPullRequestPresenter.new(pr)
           pr_attr_value = presenter.send(col[:name])
-          next if pr_attr_value.nil?
           if input_string == input_string.downcase
             pr_attr_value.to_s.downcase.include?(input_string)
           else


### PR DESCRIPTION
I did this because sometimes I am looking for pull requests from a specific
repository, or author, or tag, ect and I'd like to filter them quickly.

This adds a listener for a `/` key press for cursor which gathers all
following key presses as a string until `ENTER` is pressed. Once `ENTER` is
pressed it reduces the current pull requests collection down to a collection
of pull requests that have partial string matches in any of the columns
rendered on the screen. This filtering is slightly smart in that if you use
uppercase letters it will preserve matching by uppercase letters. If you use
lowercase letters, it will match upper and lowercase.

<del>I found that there are some caveats that I can explore if needed. The
`update_at` is a date time that during presentation is being turned into
`.to_time.ago.to_words`. Currently I am not matching against that string
representation so you cannot filter by something in that column e.g. `month`</del>
I fixed this by using the pull request presenter to run the filter against so you can
filter by `month` now.

Also, filtering is based off of what you currently see. For example, I filter
by `approved` and I would see all the pull requests with the word `approved` in
it. I can then press `/` again and type `ryan` to filter all the approved pull
requests by the word `ryan`. If I want to reset all my filters I'll have to
press `r` to force a refresh to happen and get all of the pull requests. Filters on filters! 

### Features I'd like to add to filtering:
* Be able to see the applied filters on your current list of pull requests. Here 
  
   ```
  60 Pull Requests @ 2016-09-08 10:48:02 -0700 : Page 1 of 2
  
  ```

  ```
  18 Pull Requests @ 2016-09-08 10:49:00 -0700 : Page 1 of 1
  FILTERS: 'approved'
  ```

  ```
  7 Pull Requests @ 2016-09-08 10:50:00 -0700 : Page 1 of 1
  FILTERS: 'approved', 'ryan' 
  ```

* Be able to see what you are typing as you type it indicating the filtering process. `Backspace` should removes characters and `return` should execute filter.

* Possibly Use Levenshtein to fuzzy match even with some typing mistakes.

* Filter as you type. Each letter changes the number of pull requests that match, when pressing enter it lets you move up and down the filtered list.

* Background refresh currently clears the applied filters. The background refresh should only refresh the current filtered set of pull requests.